### PR TITLE
Added syslinux package to install-deps

### DIFF
--- a/bin/install-deps
+++ b/bin/install-deps
@@ -11,7 +11,8 @@ $SUDO apt-get install \
      gnupg \
      coreutils \
      squashfs-tools \
-     genisoimage || {
+     genisoimage \
+     syslinux || {
     $PRINTERROR Package installation failed!
     exit 1
 }


### PR DESCRIPTION
The syslinux package is required for the 'isohybrid' invocation used in
make-master.

This package is not installed by default, as found with a fresh
14.04.2 installation.
