### PR TITLE
bladeRF: Updated to fetch current HEAD of master

### DIFF
--- a/config/pybombs.d/install.conf
+++ b/config/pybombs.d/install.conf
@@ -2,7 +2,7 @@
 uhd             36c8e0f8                   /usr/local/bin/uhd_find_devices
 rtl-sdr         master                  /usr/local/bin/rtl_test
 hackrf          v2015.07.2              /usr/local/bin/hackrf_info
-bladeRF         2015.07                 /usr/local/bin/bladeRF-cli
+bladeRF         19c7f7c3                /usr/local/bin/bladeRF-cli
 libiio          2015.1-r1               /usr/local/bin/iio_info
 airspy          master                  /usr/local/include/libairspy/airspy.h
 

--- a/config/pybombs.d/postinst.d/bladeRF
+++ b/config/pybombs.d/postinst.d/bladeRF
@@ -6,8 +6,8 @@ set -o nounset
 
 # Download and install associated FPGA bitstream and firmware files
 
-BLADERF_FPGA_VERSION=v0.3.4
-BLADERF_FW_VERSION=v1.8.0
+BLADERF_FPGA_VERSION=v0.4.1
+BLADERF_FW_VERSION=v1.8.1
 
 NUAND_SHARE=/usr/local/share/Nuand/bladeRF
 
@@ -19,7 +19,7 @@ NUAND_SHARE=/usr/local/share/Nuand/bladeRF
     curl -# http://nuand.com/fpga/${BLADERF_FPGA_VERSION}/hostedx115.rbf \
         -o /tmp/bladeRF/hostedx115.rbf &&
     curl -# http://nuand.com/fx3/bladeRF_fw_${BLADERF_FW_VERSION}.img \
-        -o /tmp/bladeRF/bladeRF_fw_v1.8.0.img || \
+        -o /tmp/bladeRF/bladeRF_fw_${BLADERF_FW_VERSION}.img || \
     die Unable to download bladeRF FPGA and firmware files!
 
     printinfo Downloading checksums...
@@ -28,7 +28,7 @@ NUAND_SHARE=/usr/local/share/Nuand/bladeRF
     curl -# http://nuand.com/fpga/${BLADERF_FPGA_VERSION}/hostedx115.rbf.sha256sum \
         -o /tmp/bladeRF/hostedx115.rbf.sha256sum &&
     curl -# http://nuand.com/fx3/bladeRF_fw_${BLADERF_FW_VERSION}.img.sha256sum \
-        -o /tmp/bladeRF/bladeRF_fw_v1.8.0.img.sha256sum ||
+        -o /tmp/bladeRF/bladeRF_fw_${BLADERF_FW_VERSION}.img.sha256sum ||
     die Unable to download checksums!
 
     printinfo Verifying checksums...


### PR DESCRIPTION
Until the next bladeRF release is posted, the state of master @ 19c7f7c3 is sufficiently stable for use.
