### PR TITLE
bin: Fixed kernel version check

### DIFF
--- a/bin/library.sh
+++ b/bin/library.sh
@@ -49,5 +49,5 @@ test_overlay_workdir_needed () {
     local minor=$(echo $kernel | cut -f 2 -d '.')
 
     [ "$major" -gt "3" ] ||
-    [ "$major" -eq "3" ] && [ "$minor" -gt "17" ]
+    [ "$major" -eq "3" -a "$minor" -gt "17" ]
 }


### PR DESCRIPTION
This was failing for major=4, minor=2 (XUbuntu 14.04.4) due to the precedence of || and &&.  The `&& [ "$minor" -gt "17" ]` condition was being evaluated when it wasn't intended to.

This change ensures the conditions are grouped properly.
