### PR TITLE
fixing mount of overlay filesystem

### DIFF
--- a/bin/mount-iso
+++ b/bin/mount-iso
@@ -28,11 +28,11 @@ if test_overlay_workdir_needed ; then
     workdiropt='-oworkdir='$ISOMNT_WORK
 fi
 
-$SUDO $MOUNT -t overlayfs \
+$SUDO $MOUNT -t overlay \
              -olowerdir=$ISOMNT_RO \
              -oupperdir=$ISOMNT_RW \
              $workdiropt \
-             overlayfs $ISOMNT_RW || \
+             overlay $ISOMNT_RW || \
     die Mounting of Ubuntu ISO read-write overlay failed!
 
 exit 0

--- a/bin/mount-rootfs
+++ b/bin/mount-rootfs
@@ -24,11 +24,11 @@ if test_overlay_workdir_needed ; then
     workdiropt='-oworkdir='$ROOTFSMNT_WORK
 fi
 
-$SUDO $MOUNT -t overlayfs \
+$SUDO $MOUNT -t overlay \
              -olowerdir=$ROOTFSMNT_RO \
              -oupperdir=$ROOTFSMNT_RW \
              $workdiropt \
-             overlayfs $ROOTFSMNT_RW || \
+             overlay $ROOTFSMNT_RW || \
     die Mounting of Ubuntu root filesystem read-write overlay failed!
 
 exit 0


### PR DESCRIPTION
In current Ubuntu 16.04 (Kernel 4.4), make fails while mounting the overlay filesystem using mount-iso and mount-rootfs with

    mount: unknown filesystem type 'overlayfs'

Calling

    mount -t overlayfs

is deprecated, since it has been merged to mainline it shall be used with 

    mount -t overlay

See https://www.kernel.org/doc/Documentation/filesystems/overlayfs.txt
